### PR TITLE
Automatically validate schema on PR/build using GitHub Actions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,36 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Schema Validation
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Runs a single command using the runners shell
+      - name: Run a one-line script
+        run: echo Hello, world!
+
+      # Runs a set of commands using the runners shell
+      - name: Run a multi-line script
+        run: |
+          echo Add other actions to build,
+          echo test, and deploy your project.

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,24 +13,47 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build:
-    # The type of runner that the job will run on
+  # Label of the container job
+  container-job:
+    # Containers must run in Linux based operating systems
     runs-on: ubuntu-latest
+    # Docker Hub image that `container-job` executes in
+    container: node:10-alpine
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
+    # Service containers to run with `container-job`
+    services:
+      # Label used to access the service container
+      postgres:
+        # Docker Hub image
+        image: postgres
+        # Provide the password for postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      # Downloads a copy of the code in your repository before running CI tests
+      - name: Check out repository code
+        uses: actions/checkout@v2
 
-      # Runs a single command using the runners shell
-      - name: Run a one-line script
-        run: echo Hello, world!
+      # Performs a clean installation of all dependencies in the `package.json` file
+      # For more information, see https://docs.npmjs.com/cli/ci.html
+      - name: Install dependencies
+        run: npm ci
 
-      # Runs a set of commands using the runners shell
-      - name: Run a multi-line script
-        run: |
-          echo Add other actions to build,
-          echo test, and deploy your project.
+      - name: Connect to PostgreSQL
+        # Runs a script that creates a PostgreSQL client, populates
+        # the client with data, and retrieves data
+        run: node client.js
+        # Environment variable used by the `client.js` script to create a new PostgreSQL client.
+        env:
+          # The hostname used to communicate with the PostgreSQL service container
+          POSTGRES_HOST: postgres
+          # The default PostgreSQL port
+          POSTGRES_PORT: 5432

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -42,15 +42,10 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v2
 
-      # Performs a clean installation of all dependencies in the `package.json` file
-      # For more information, see https://docs.npmjs.com/cli/ci.html
-      - name: Install dependencies
-        run: npm ci
-
       - name: Connect to PostgreSQL
         # Runs a script that creates a PostgreSQL client, populates
         # the client with data, and retrieves data
-        run: node client.js
+        run: python --version
         # Environment variable used by the `client.js` script to create a new PostgreSQL client.
         env:
           # The hostname used to communicate with the PostgreSQL service container

--- a/README.md
+++ b/README.md
@@ -92,3 +92,8 @@ GRANT SELECT ON ministry TO ${anonuser};
 * FLYWAY_PLACEHOLDERS_ANONUSER
 * FLYWAY_PLACEHOLDERS_SERVICEUSER
 * FLYWAY_PLACEHOLDERS_READONLYUSER
+
+## Development
+
+Launch PG database server in one line: `docker run -d --name refpg -e POSTGRES_PASSWORD=postgres -p 5432:5432 postgres`. This uses standard port, username `postgres` and password `postgres`.
+

--- a/README.md
+++ b/README.md
@@ -8,15 +8,19 @@ Each Table must contain a comment in JSON format containing the following entiti
 * description
 * schemalastupdated
 * dataversion
-* owner
+* `owner` - a group email like `cop@homeoffice.gov.uk`
+
+and these columns are required:
+
+* validfrom
+* validto
+
 
 Each Column must contain a comment in JSON format containing the following entities:
 
 * label
 * description
 * summaryview
-* validfrom
-* validto
 
 One column must also contain the comment:
 

--- a/docker/flyway_reference_docker.conf
+++ b/docker/flyway_reference_docker.conf
@@ -1,2 +1,2 @@
 flyway.table=flywayreferencehistory
-flyway.target=116
+flyway.target=117

--- a/python/sv.py
+++ b/python/sv.py
@@ -1,0 +1,28 @@
+# pip install psycopg2
+
+import psycopg2
+from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
+from psycopg2.errors import DuplicateDatabase
+
+import os
+
+# connect and create db
+conn = psycopg2.connect(host="localhost", database="postgres", user="postgres", password="mypass")
+conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+cur = conn.cursor()
+try:
+    cur.execute("CREATE DATABASE ref;")
+except DuplicateDatabase:
+    pass
+
+# find scripts
+root = "../../schemas/reference"
+_, _, files =  next(os.walk(root))
+
+# sort by version number as integer
+sfiles = sorted(files, key=lambda fn: int(fn[1:].split("_")[0]))
+
+for i, fn in enumerate(sfiles, start=1):
+    print(f"processing {fn} (#{i})")
+    path = os.path.join(root, fn)
+    print(path)

--- a/python/sv.py
+++ b/python/sv.py
@@ -82,6 +82,18 @@ def list_tables() -> List[str]:
     return tables
 
 
+def list_columns(table_name: str):
+    cur = conn.cursor()
+    cur.execute(
+        f"select column_name, ordinal_position, data_type from information_schema.columns where table_name='{table_name}';")
+    cols = cur.fetchall()
+
+    cols = [(x[0], get_column_comment_json(cur, table_name, x[1])) for x in cols]
+
+    cur.close()
+    return cols
+
+
 def get_table_comment_json(cur, table_name: str):
     cur.execute(f"select obj_description('public.{table_name}'::regclass)")
     jt = cur.fetchone()[0]
@@ -89,10 +101,37 @@ def get_table_comment_json(cur, table_name: str):
     try:
         j = json.loads(jt)
     except JSONDecodeError:
-        print(f"  comment is not a valid JSON.")
         return None
 
     return j
+
+
+def get_column_comment_json(cur, table_name: str, column_index: str):
+    cur.execute(f"select col_description('public.{table_name}'::regclass, {column_index});")
+    jt = cur.fetchone()[0]
+    if not jt:
+        return None
+
+    try:
+        j = json.loads(jt)
+    except JSONDecodeError:
+        return None
+
+    return j
+
+
+def print_error(text: str, err_count: int, level=1) -> int:
+    print(level * "  ", end="")
+    print("!!!", end="")
+    print(text)
+    return err_count + 1
+
+
+def check_j_present(j, props, err_count, level) -> int:
+    for prop in props:
+        if not j.get(prop):
+            err_count = print_error(f"'{prop}' is missing", err_count, level)
+    return err_count
 
 
 def validate_tables(table_names: List[str]):
@@ -102,32 +141,55 @@ def validate_tables(table_names: List[str]):
         print(f"validating '{table}'")
         j = get_table_comment_json(cur, table)
         if not j:
-            err_count += 1
+            err_count = print_error("comment is not a valid JSON.", err_count)
             continue
 
-        # description is present
-        if not j.get("description"):
-            print("  description missing.")
+        err_count = check_j_present(j,
+                                    ["description", "schemalastupdated", "dataversion", "owner"],
+                                    err_count, 1)
 
         # schemalastupdated is present and is in dd/MM/yyyy format
         schemalastupdated = j.get("schemalastupdated")
-        if not schemalastupdated:
-            print("  schemalastupdated missing")
-        try:
-            datetime.strptime(schemalastupdated, "%d/%m/%Y")
-        except ValueError:
-            print(f"  schemalastupdated needs to be in dd/MM/yyyy format, but the value found was '{schemalastupdated}'")
+        if schemalastupdated:
+            try:
+                datetime.strptime(schemalastupdated, "%d/%m/%Y")
+            except ValueError:
+                err_count = print_error(
+                    f"schemalastupdated needs to be in dd/MM/yyyy format, but the value found was '{schemalastupdated}'",
+                    err_count)
 
-        # dataversion is present
-        if not j.get("dataversion"):
-            print(f"  dataversion is missing")
+        columns = list_columns(table)
+        bk_cols = []
+        # check json comment validity
+        for column in columns:
+            name = column[0]
+            j = column[1]
+            print(f"  validating '{name}'")
+            if not j:
+                err_count = print_error("comment is not a valid JSON", err_count, 2)
+            else:
+                err_count = check_j_present(j, ["label", "description", "summaryview"], err_count, 2)
 
-        # owner is present
-        if not j.get("owner"):
-            print(f"  owner is missing")
+                if j.get("businesskey"):
+                    bk_cols.append(name)
+
+        # there should be only one businesskey
+        if len(bk_cols) != 1:
+            if len(bk_cols):
+                err_count = print_error(
+                    f"exactly one column needs to have 'businesskey' attribute, following do: {bk_cols}",
+                    err_count)
+            else:
+                err_count = print_error("one of the columns must have 'businesskey' attribute", err_count)
+
+        # check we have validfrom and validto columns
+        cnames = [x[0] for x in columns]
+        if "validfrom" not in cnames:
+            err_count = print_error("missing 'validfrom' column", err_count)
+        if "validto" not in cnames:
+            err_count = print_error("missing 'validto' column", err_count)
 
     return err_count
-
 
 
 sfiles, sfiles_max = find_and_sort_scripts()
@@ -137,5 +199,8 @@ apply_scripts(sfiles)
 tables = list_tables()
 
 err_count = validate_tables(tables)
+
+if err_count:
+    print(f"{err_count} error(s).")
 
 exit(err_count)

--- a/python/sv.py
+++ b/python/sv.py
@@ -7,7 +7,7 @@ from psycopg2.errors import DuplicateDatabase
 import os
 
 # connect and create db
-conn = psycopg2.connect(host="localhost", database="postgres", user="postgres", password="postgres")
+conn = psycopg2.connect(host="postgres", database="postgres", user="postgres", password="postgres")
 conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
 cur = conn.cursor()
 try:

--- a/python/sv.py
+++ b/python/sv.py
@@ -37,6 +37,7 @@ def ensure_db():
     except DuplicateDatabase:
         pass
 
+ensure_db()
 
 # reconnect to the reference database
 conn = psycopg2.connect(host=host, database=db_name, user="postgres", password="postgres")
@@ -202,8 +203,6 @@ sfiles, sfiles_max = find_and_sort_scripts()
 if sfiles_max != flyway_target:
     print(f"flyway.target in docker/flyway_reference_docker.conf is {flyway_target} but the last script number is {sfiles_max}")
     exit(1)
-
-ensure_db()
 
 apply_scripts(sfiles)
 

--- a/python/sv.py
+++ b/python/sv.py
@@ -203,6 +203,8 @@ if sfiles_max != flyway_target:
     print(f"flyway.target in docker/flyway_reference_docker.conf is {flyway_target} but the last script number is {sfiles_max}")
     exit(1)
 
+ensure_db()
+
 apply_scripts(sfiles)
 
 tables = list_tables()

--- a/python/sv.py
+++ b/python/sv.py
@@ -1,28 +1,141 @@
 # pip install psycopg2
+from typing import Tuple, List
 
 import psycopg2
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
-from psycopg2.errors import DuplicateDatabase
-
+# noinspection PyUnresolvedReferences
+from psycopg2.errors import DuplicateDatabase, DuplicateObject, DuplicateTable
 import os
+import json
+from json.decoder import JSONDecodeError
+import configparser
+from datetime import datetime
+
+db_name = "ref"
+service_user_name = "postgres"
+ro_user_name = "postgres"
+anon_user_name = "postgres"
+auth_user_role = "role_au"
+schema_name = "public"
+script_root = "../schemas/reference"
 
 # connect and create db
-conn = psycopg2.connect(host="postgres", database="postgres", user="postgres", password="postgres")
+host = os.getenv("POSTGRES_HOST", "postgres")
+
+
+def ensure_db():
+    conn = psycopg2.connect(host=host, database="postgres", user="postgres", password="postgres")
+    conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+    cur = conn.cursor()
+    try:
+        cur.execute(f"CREATE DATABASE {db_name};")
+    except DuplicateDatabase:
+        pass
+
+
+# reconnect to the reference database
+conn = psycopg2.connect(host=host, database=db_name, user="postgres", password="postgres")
 conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
-cur = conn.cursor()
-try:
-    cur.execute("CREATE DATABASE ref;")
-except DuplicateDatabase:
-    pass
 
-# find scripts
-root = "../schemas/reference"
-_, _, files =  next(os.walk(root))
 
-# sort by version number as integer
-sfiles = sorted(files, key=lambda fn: int(fn[1:].split("_")[0]))
+def find_and_sort_scripts() -> Tuple[List[str], int]:
+    # find scripts
+    _, _, files = next(os.walk(script_root))
 
-for i, fn in enumerate(sfiles, start=1):
-    print(f"processing {fn} (#{i})")
-    path = os.path.join(root, fn)
-    print(path)
+    # sort by version number as integer
+    files = [(fn, (int(fn[1:].split("_")[0]))) for fn in files]
+    sfiles = sorted(files, key=lambda t: t[1])
+
+    return [x[0] for x in sfiles], sfiles[-1][1]
+
+
+def apply_scripts(script_files):
+    cur = conn.cursor()
+    for i, fn in enumerate(script_files, start=1):
+        print(f"processing {fn} (#{i})")
+        path = os.path.join(script_root, fn)
+        with open(path, "r") as file:
+            script = file.read()
+
+        script = script.replace("${serviceuser}", service_user_name)
+        script = script.replace("${readonlyuser}", ro_user_name)
+        script = script.replace("${authenticatoruser}", auth_user_role)
+        script = script.replace("${schema}", schema_name)
+        script = script.replace("${anonuser}", anon_user_name)
+
+        try:
+            cur.execute(script)
+        except (DuplicateObject, DuplicateTable):
+            pass
+
+        # print(script)
+
+    cur.close()
+
+
+def list_tables() -> List[str]:
+    # get list of tables
+    cur = conn.cursor()
+    cur.execute("select table_name from information_schema.tables where table_schema='public';")
+    tables = cur.fetchall()
+    tables = [x[0] for x in tables]
+    return tables
+
+
+def get_table_comment_json(cur, table_name: str):
+    cur.execute(f"select obj_description('public.{table_name}'::regclass)")
+    jt = cur.fetchone()[0]
+
+    try:
+        j = json.loads(jt)
+    except JSONDecodeError:
+        print(f"  comment is not a valid JSON.")
+        return None
+
+    return j
+
+
+def validate_tables(table_names: List[str]):
+    err_count = 0
+    cur = conn.cursor()
+    for table in table_names:
+        print(f"validating '{table}'")
+        j = get_table_comment_json(cur, table)
+        if not j:
+            err_count += 1
+            continue
+
+        # description is present
+        if not j.get("description"):
+            print("  description missing.")
+
+        # schemalastupdated is present and is in dd/MM/yyyy format
+        schemalastupdated = j.get("schemalastupdated")
+        if not schemalastupdated:
+            print("  schemalastupdated missing")
+        try:
+            datetime.strptime(schemalastupdated, "%d/%m/%Y")
+        except ValueError:
+            print(f"  schemalastupdated needs to be in dd/MM/yyyy format, but the value found was '{schemalastupdated}'")
+
+        # dataversion is present
+        if not j.get("dataversion"):
+            print(f"  dataversion is missing")
+
+        # owner is present
+        if not j.get("owner"):
+            print(f"  owner is missing")
+
+    return err_count
+
+
+
+sfiles, sfiles_max = find_and_sort_scripts()
+
+apply_scripts(sfiles)
+
+tables = list_tables()
+
+err_count = validate_tables(tables)
+
+exit(err_count)

--- a/python/sv.py
+++ b/python/sv.py
@@ -7,7 +7,7 @@ from psycopg2.errors import DuplicateDatabase
 import os
 
 # connect and create db
-conn = psycopg2.connect(host="localhost", database="postgres", user="postgres", password="mypass")
+conn = psycopg2.connect(host="localhost", database="postgres", user="postgres", password="postgres")
 conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
 cur = conn.cursor()
 try:

--- a/python/sv.py
+++ b/python/sv.py
@@ -22,6 +22,11 @@ script_root = "../schemas/reference"
 # connect and create db
 host = os.getenv("POSTGRES_HOST", "postgres")
 
+config = configparser.ConfigParser()
+with open("../docker/flyway_reference_docker.conf") as stream:
+    config.read_string("[top]\n" + stream.read())
+
+flyway_target = int(config["top"]["flyway.target"])
 
 def ensure_db():
     conn = psycopg2.connect(host=host, database="postgres", user="postgres", password="postgres")
@@ -193,6 +198,10 @@ def validate_tables(table_names: List[str]):
 
 
 sfiles, sfiles_max = find_and_sort_scripts()
+
+if sfiles_max != flyway_target:
+    print(f"flyway.target in docker/flyway_reference_docker.conf is {flyway_target} but the last script number is {sfiles_max}")
+    exit(1)
 
 apply_scripts(sfiles)
 

--- a/python/sv.py
+++ b/python/sv.py
@@ -16,7 +16,7 @@ except DuplicateDatabase:
     pass
 
 # find scripts
-root = "../../schemas/reference"
+root = "../schemas/reference"
 _, _, files =  next(os.walk(root))
 
 # sort by version number as integer

--- a/schemas/reference/V117__validation.sql
+++ b/schemas/reference/V117__validation.sql
@@ -1,0 +1,13 @@
+-- not a valid JSON
+COMMENT ON TABLE tdacodes IS '{"label": "Governance bodies", "description": "A list of governance bodies and their associated codes.", "owner": "cop@homeoffice.gov.uk", "schemalastupdated": "03/12/2020", "dataversion": 1}';
+COMMENT ON TABLE lasttrained IS '{"label": "Last Trained", "description": "When were you last trained periods", "owner": "cop@homeoffice.gov.uk", "schemalastupdated": "03/12/2020", "dataversion": 1}';
+COMMENT ON TABLE traininglevels IS '{"label": "Training levels", "description": "Training levels for different courses.", "owner": "cop@homeoffice.gov.uk", "schemalastupdated": "03/12/2020", "dataversion": 1}';
+COMMENT ON TABLE covidunablereasons IS '{"label": "Covid self declaration failure reasons", "description": "Reasons why the passenger Covid self declaration was not done online before travel", "owner": "cop@homeoffice.gov.uk", "schemalastupdated": "03/12/2020", "dataversion": 1}';
+COMMENT ON TABLE partneremaildistribution IS '{"label": "Partner Emails", "description": "Email distribution list for external partners of the Fast Parcels capability.", "owner": "cop@homeoffice.gov.uk", "schemalastupdated": "03/12/2020", "dataversion": 1}';
+
+-- schemalastupdated was in a wrong format
+COMMENT ON TABLE bordercrossingmode IS '{"label": "Type of Border Crossing", "description": "Methods of crossing the border", "owner": "cop@homeoffice.gov.uk", "schemalastupdated": "03/12/2020", "dataversion": 1}';
+
+-- owner missing
+COMMENT ON TABLE honotificationreasons IS '{"label": "HO Notificaiton Reason", "description": "A list of reasons why a notification may be sent", "owner": "cop@homeoffice.gov.uk", "schemalastupdated": "24/11/2020", "dataversion": 1}';
+COMMENT ON TABLE is81riskfactors IS '{"label": "Risk factors", "description": "Risk factors to be considered when issuing an IS81", "owner": "cop@homeoffice.gov.uk", "schemalastupdated": "24/11/2020", "dataversion": 1}';

--- a/schemas/reference/V117__validation.sql
+++ b/schemas/reference/V117__validation.sql
@@ -14,3 +14,53 @@ COMMENT ON TABLE is81riskfactors IS '{"label": "Risk factors", "description": "R
 
 -- businessKey should be lowercase
 COMMENT ON COLUMN flightlookup.id IS '{"label": "Identifier", "businesskey": true, "description": "Unique identifying column, coposed from flight number and flight time.", "summaryview": "false"}';
+
+-- businesskey was missing
+COMMENT ON COLUMN is81riskfactors.id IS '{"label": "Identifier", "businesskey": true, "description": "Unique identifying column", "summaryview": "false"}';
+COMMENT ON COLUMN honotificationreasons.id IS '{"label": "Identifier", "description": "Unique identifying column", "summaryview": "false", "businesskey": true}';
+COMMENT ON COLUMN tdareasons.id IS '{"label": "Identifier", "description": "Unique identifying column", "summaryview": "false", "businesskey": true}';
+
+-- more than one businesskey, update comment to remove the rest
+COMMENT ON COLUMN currency.currency IS '{"label": "Currency", "description": "The name of the currency.", "summaryview": "true"}';
+COMMENT ON COLUMN department.name IS '{"label": "Department name", "description": "The name of the department.", "summaryview": "true"}';
+COMMENT ON COLUMN branch.name IS '{"label": "Name", "description": "The name of the branch or region.", "summaryview": "true", "aliases": "region"}';
+COMMENT ON COLUMN country.name IS '{"label": "Country name", "description": "The name of the country, territory or geographic area.", "summaryview": "true"}';
+COMMENT ON COLUMN carrierlist.name IS '{"label": "Carrier name", "description": "The name of the carrier.", "summaryview": "true"}';
+COMMENT ON COLUMN bflocationtype.description IS '{"label": "Description", "description": "Description of port crossing.", "summaryview": "true"}';
+COMMENT ON COLUMN icao.name IS '{"label": "Name", "description": "ICAO site name", "summaryview": "true"}';
+COMMENT ON COLUMN legtypes.description IS '{"label": "Description", "description": "A description of the journey type.", "summaryview": "true"}';
+COMMENT ON COLUMN targetmode.mode IS '{"label": "Target mode", "description": "The targeting mode type.", "summaryview": "true"}';
+COMMENT ON COLUMN unlocode.name IS '{"label": "Name", "description": "Location name", "summaryview": "true"}';
+COMMENT ON COLUMN workarea.area IS '{"label": "Area", "description": "A short description of the working area.", "summaryview": "true"}';
+COMMENT ON COLUMN activities.id IS '{"label": "Identifier", "description": "Unique identifying column.", "summaryview": "false", "businesskey": true}';
+COMMENT ON COLUMN activities.activity IS '{"label": "Activity", "description": "A description of the activity.", "summaryview": "true"}';
+COMMENT ON COLUMN activities.activitytypeid IS '{"label": "Activity type ID", "description": "Link to activity type entity.", "summaryview" : "false"}';
+COMMENT ON COLUMN tdacodes.name IS '{"label": "Name", "description": "The name of the governing body.", "summaryview": "true"}';
+COMMENT ON COLUMN address.line1 IS '{"label": "Address line 1", "description": "First line of address.", "summaryview": "true"}';
+COMMENT ON COLUMN location.name IS '{"label": "Name", "description": "Location name", "summaryview": "true"}';
+COMMENT ON COLUMN technicalprojectstatus.status IS '{"label": "Status", "description": "The status of the project.", "summaryview": "true"}';
+COMMENT ON COLUMN division.name IS '{"label": "Name", "description": "The division name.", "summaryview": "true"}';
+COMMENT ON COLUMN command.name IS '{"label": "Name", "description": "The name of the command.", "summaryview": "true"}';
+COMMENT ON COLUMN team.name IS '{"label": "Name", "description": "The name of the team.", "summaryview": "true"}';
+COMMENT ON COLUMN technicalprojects.name IS '{"label": "Name", "description": "The name of the project.", "summaryview": "true"}';
+COMMENT ON COLUMN ferries.id IS '{"label": "Identifier", "description": "Unique identifying column.", "summaryview": "false", "businesskey": true}';
+COMMENT ON COLUMN ferries.name IS '{"label": "Ferry name", "description": "The name of the ferry.", "summaryview": "true"}';
+COMMENT ON COLUMN ferries.carrierid IS '{"label": "Carrier ID", "description": "Link to the carrier list table by id.", "summaryview": "true"}';
+COMMENT ON COLUMN controlstrategy.strategy IS '{"label": "Strategy", "description": "The strategy descriptor.", "summaryview": "true"}';
+COMMENT ON COLUMN tdareasons.reason IS '{"label": "Reason", "description": "The reason for the request.", "summaryview": "true"}';
+COMMENT ON COLUMN maritimezone.name IS '{"label": "Name", "description": "The non-abbreviated name of the zone.", "summaryview": "true"}';
+COMMENT ON COLUMN eventclassification.label IS '{"label": "Label", "description": "The label for the breach type", "summaryview": "true"}';
+COMMENT ON COLUMN reasons.reason IS '{"label": "Description", "description": "The reason for the seizure.", "summaryview": "false"}';
+
+-- no JSON / not a valid JSON on column
+COMMENT ON COLUMN tdaapprovalstatus.updatedby IS '{"label": "Updated By", "description": "Record updated by", "summaryview": "false"}';
+COMMENT ON COLUMN eventclassification.id IS '{"label": "Identifier", "description": "Database unique identity record.", "businesskey": true, "summaryview": "false"}';
+
+
+
+
+
+
+
+
+

--- a/schemas/reference/V117__validation.sql
+++ b/schemas/reference/V117__validation.sql
@@ -11,3 +11,6 @@ COMMENT ON TABLE bordercrossingmode IS '{"label": "Type of Border Crossing", "de
 -- owner missing
 COMMENT ON TABLE honotificationreasons IS '{"label": "HO Notificaiton Reason", "description": "A list of reasons why a notification may be sent", "owner": "cop@homeoffice.gov.uk", "schemalastupdated": "24/11/2020", "dataversion": 1}';
 COMMENT ON TABLE is81riskfactors IS '{"label": "Risk factors", "description": "Risk factors to be considered when issuing an IS81", "owner": "cop@homeoffice.gov.uk", "schemalastupdated": "24/11/2020", "dataversion": 1}';
+
+-- businessKey should be lowercase
+COMMENT ON COLUMN flightlookup.id IS '{"label": "Identifier", "businesskey": true, "description": "Unique identifying column, coposed from flight number and flight time.", "summaryview": "false"}';


### PR DESCRIPTION
Performs validations on ref data schema according to specs in readme.txt.

It stands up a clean Postres instance in a container, and runs python script which:

1) creates empty reference db.
2) rolls scripts in the order.
3) checks that JSON comments on both tables and columns are valid

![image](https://user-images.githubusercontent.com/3155189/104588982-1e979880-5661-11eb-99ad-20c38dea112a.png)

4) checks that flyway number is correct

![image](https://user-images.githubusercontent.com/3155189/104589042-32db9580-5661-11eb-9112-704f27d8e942.png)

5) validates businesskey is present

![image](https://user-images.githubusercontent.com/3155189/104593482-abddeb80-5667-11eb-8ca7-806f950d8375.png)

and exactly one!

6) validates required properties on JSON schemas for tables and columns are present

7) validates required columns on tables are present

This also fixes 44 errors found in existing schema.