### PR TITLE
Local Mini Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,14 +120,10 @@ mini_flyway_1 | Successfully applied 117 migrations to schema "public" (executio
 
 The server will run as long as your terminal session is open. Closing it completely destroys services and data locally. Restart to get it back again.
 
+> Befause of the way [PostgREST caches schema](https://postgrest.org/en/v7.0.0/admin.html#schema-reloading), you need to run `docker-compose kill -s SIGUSR1 rest` after flyway has finished the job.
+
 ### Making Changes
 
 1. Create a new flyway file in `schemas/reference` - follow [flyway documentation](https://flywaydb.org/documentation/) if you are not familiar with this system. Look at the existing scripts and try to be like a ninja - make your scripts blend in.
 2. Change `flyway.target` in `docker/flyway_reference_docker.conf` to your script number.
 3. Raise a PR and wait for validation to complete. Check build logs if anything goes wrong - you will get a detailed reason why something is not working.
-
-### Reloading Schema
-
-If you are using PostgREST and need to refresh schema, execute the following command:
-
-`docker-compose kill -s SIGUSR1 rest`

--- a/README.md
+++ b/README.md
@@ -99,5 +99,35 @@ GRANT SELECT ON ministry TO ${anonuser};
 
 ## Development
 
-Launch PG database server in one line: `docker run -d --name refpg -e POSTGRES_PASSWORD=postgres -p 5432:5432 postgres`. This uses standard port, username `postgres` and password `postgres`.
+### Setting Up
 
+This guide assumes you've already cloned this repo and have Docker available locally.
+
+Go to `mini` folder - there is a `docker-compose.yml` file that performs the following:
+1. Creates Postgres server - `localhost:5432`
+2. Creates PostgREST API - `localhost:3000`
+3. Applies all the flyway scripts on top of the local database.
+
+```bash
+❯ docker compose up
+...
+mini_flyway_1 | Migrating schema "public" to version "115 - is81riskfactors"
+mini_flyway_1 | Migrating schema "public" to version "116 - flightlookup"
+mini_flyway_1 | Migrating schema "public" to version "117 - validation"
+mini_flyway_1 | Successfully applied 117 migrations to schema "public" (execution time 00:04.489s)
+
+```
+
+The server will run as long as your terminal session is open. Closing it completely destroys services and data locally. Restart to get it back again.
+
+### Making Changes
+
+1. Create a new flyway file in `schemas/reference` - follow [flyway documentation](https://flywaydb.org/documentation/) if you are not familiar with this system. Look at the existing scripts and try to be like a ninja - make your scripts blend in.
+2. Change `flyway.target` in `docker/flyway_reference_docker.conf` to your script number.
+3. Raise a PR and wait for validation to complete. Check build logs if anything goes wrong - you will get a detailed reason why something is not working.
+
+### Reloading Schema
+
+If you are using PostgREST and need to refresh schema, execute the following command:
+
+`docker-compose kill -s SIGUSR1 rest`

--- a/docker/flyway_reference_docker.conf
+++ b/docker/flyway_reference_docker.conf
@@ -1,2 +1,2 @@
 flyway.table=flywayreferencehistory
-flyway.target=117
+flyway.target=118

--- a/mini/docker-compose.yml
+++ b/mini/docker-compose.yml
@@ -1,0 +1,40 @@
+# docker-compose.yml
+
+version: '3'
+services:
+  rest:
+    image: postgrest/postgrest
+    ports:
+      - "3000:3000"
+    links:
+      - db:db
+    environment:
+      PGRST_DB_URI: postgres://app_user:password@db:5432/ref
+      PGRST_DB_SCHEMA: public
+      PGRST_DB_ANON_ROLE: app_user #In production this role should not be the same as the one used for the connection
+    depends_on:
+      - db
+  db:
+    image: postgres
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_DB: ref
+      POSTGRES_USER: app_user
+      POSTGRES_PASSWORD: password
+  flyway:
+    image: flyway/flyway
+    command: -url=jdbc:postgresql://db:5432/ref -user=app_user -password=password -connectRetries=60 migrate
+    volumes:
+      - ./../schemas/reference:/flyway/sql
+      - ./../docker:/flyway/conf
+    environment:
+      FLYWAY_CONFIG_FILES: ./conf/flyway_reference_docker.conf
+      FLYWAY_PLACEHOLDERS_SCHEMA: public
+      FLYWAY_PLACEHOLDERS_AUTHENTICATORUSER: authenticatorreference
+      FLYWAY_PLACEHOLDERS_AUTHENTICATORPASSWORD: auth1234
+      FLYWAY_PLACEHOLDERS_ANONUSER: webanon
+      FLYWAY_PLACEHOLDERS_SERVICEUSER: servicereference
+      FLYWAY_PLACEHOLDERS_READONLYUSER: readonlyreference
+    depends_on:
+      - db

--- a/schemas/reference/V118__extstate.sql
+++ b/schemas/reference/V118__extstate.sql
@@ -1,0 +1,23 @@
+CREATE TABLE _data_change_history (
+  installedon  TIMESTAMP DEFAULT NOW() NOT NULL PRIMARY KEY,
+  scriptname   VARCHAR(100) NOT NULL,
+
+  validfrom TIMESTAMP WITH TIME ZONE,
+  validto TIMESTAMP WITH TIME ZONE,
+  updatedby VARCHAR(60) NULL
+);
+
+-- Table comment
+COMMENT ON TABLE _data_change_history IS '{"label": "Data State", "owner": "cop@homeoffice.gov.uk", "description": "", "schemalastupdated": "08/01/2021", "dataversion": 1}';
+
+-- Column comments
+COMMENT ON COLUMN _data_change_history.installedon IS '{"label": "Installation Date", "businessKey": true, "description": "Date of script installation.", "summaryview": "false"}';
+COMMENT ON COLUMN _data_change_history.scriptname IS '{"label": "Script Name", "description": "Script name.", "summaryview": "false"}';
+
+COMMENT ON COLUMN flightlookup.validfrom IS '{"label": "Valid from date", "description": "Valid from date.", "summaryview": "false"}';
+COMMENT ON COLUMN flightlookup.validto IS '{"label": "Valid to date", "description": "Valid to date.", "summaryview": "false"}';
+COMMENT ON COLUMN flightlookup.updatedby IS '{"label": "Updated By", "description": "Record updated by", "summaryview": "false"}';
+
+-- GRANTs
+GRANT SELECT,INSERT,UPDATE ON flightlookup TO ${serviceuser};
+GRANT SELECT ON flightlookup TO ${readonlyuser};

--- a/schemas/reference/V118__extstate.sql
+++ b/schemas/reference/V118__extstate.sql
@@ -19,5 +19,5 @@ COMMENT ON COLUMN _data_change_history.validto IS '{"label": "Valid to date", "d
 COMMENT ON COLUMN _data_change_history.updatedby IS '{"label": "Updated By", "description": "Record updated by", "summaryview": "false"}';
 
 -- GRANTs
-GRANT SELECT,INSERT,UPDATE ON flightlookup TO ${serviceuser};
-GRANT SELECT ON flightlookup TO ${readonlyuser};
+GRANT SELECT,INSERT,UPDATE ON _data_change_history TO ${serviceuser};
+GRANT SELECT ON _data_change_history TO ${readonlyuser};

--- a/schemas/reference/V118__extstate.sql
+++ b/schemas/reference/V118__extstate.sql
@@ -8,15 +8,15 @@ CREATE TABLE _data_change_history (
 );
 
 -- Table comment
-COMMENT ON TABLE _data_change_history IS '{"label": "Data State", "owner": "cop@homeoffice.gov.uk", "description": "", "schemalastupdated": "08/01/2021", "dataversion": 1}';
+COMMENT ON TABLE _data_change_history IS '{"label": "Data State", "owner": "cop@homeoffice.gov.uk", "description": "Data State.", "schemalastupdated": "08/01/2021", "dataversion": 1}';
 
 -- Column comments
-COMMENT ON COLUMN _data_change_history.installedon IS '{"label": "Installation Date", "businessKey": true, "description": "Date of script installation.", "summaryview": "false"}';
+COMMENT ON COLUMN _data_change_history.installedon IS '{"label": "Installation Date", "businesskey": true, "description": "Date of script installation.", "summaryview": "false"}';
 COMMENT ON COLUMN _data_change_history.scriptname IS '{"label": "Script Name", "description": "Script name.", "summaryview": "false"}';
 
-COMMENT ON COLUMN flightlookup.validfrom IS '{"label": "Valid from date", "description": "Valid from date.", "summaryview": "false"}';
-COMMENT ON COLUMN flightlookup.validto IS '{"label": "Valid to date", "description": "Valid to date.", "summaryview": "false"}';
-COMMENT ON COLUMN flightlookup.updatedby IS '{"label": "Updated By", "description": "Record updated by", "summaryview": "false"}';
+COMMENT ON COLUMN _data_change_history.validfrom IS '{"label": "Valid from date", "description": "Valid from date.", "summaryview": "false"}';
+COMMENT ON COLUMN _data_change_history.validto IS '{"label": "Valid to date", "description": "Valid to date.", "summaryview": "false"}';
+COMMENT ON COLUMN _data_change_history.updatedby IS '{"label": "Updated By", "description": "Record updated by", "summaryview": "false"}';
 
 -- GRANTs
 GRANT SELECT,INSERT,UPDATE ON flightlookup TO ${serviceuser};


### PR DESCRIPTION
Allow creation of a local mini server for ref data.

Document how to run it.

Create a new table `_data_change_history` that can be used by external bulk data loaders to store data state.